### PR TITLE
Allow request timeout configuration.

### DIFF
--- a/lib/amqparty.rb
+++ b/lib/amqparty.rb
@@ -35,11 +35,17 @@ module AMQParty
     end
 
     def self.default_options
-      {amqp_client_options: {host: configuration.amqp_host}}
+      {
+        amqp_client_options: {
+          host: configuration.amqp_host
+        },
+        request_timeout: configuration.request_timeout
+      }
     end
 
     class Configuration
       attr_accessor :amqp_host
+      attr_accessor :request_timeout
     end
 end
 

--- a/lib/amqparty/request.rb
+++ b/lib/amqparty/request.rb
@@ -23,8 +23,9 @@ module AMQParty
         body = options[:body] || ""
         body = HTTParty::HashConversions.to_params(options[:body]) if body.is_a?(Hash)
         headers = options[:headers] || {}
+        timeout = options[:timeout] || 5
 
-        response = client.request(path, {body: body, http_method: method_name, headers: headers, timeout: 5})
+        response = client.request(path, {body: body, http_method: method_name, headers: headers, timeout: timeout })
 
         klass = Net::HTTPResponse.send(:response_class,response.response_code.to_s)
         http_response = klass.new("1.1", response.response_code, "Found")

--- a/spec/amqparty_classmethods_spec.rb
+++ b/spec/amqparty_classmethods_spec.rb
@@ -38,6 +38,13 @@ describe AMQParty do
       end
       expect(AMQParty.configuration.amqp_host).to eq('localhost')
     end
+
+    it "allows configuration of a request timeout" do
+      AMQParty.configure do |c|
+        c.request_timeout = 10
+      end
+      expect(AMQParty.configuration.request_timeout).to eq(10)
+    end
   end
 
   describe '#get' do


### PR DESCRIPTION
Added the ability to specify a request timeout to the AMQParty configuration object.  The default is still 5 seconds if this is not provided.
